### PR TITLE
New FUSE API endpoint: /iex/historicalPrice.

### DIFF
--- a/src/main/java/org/galatea/starter/domain/IexHistoricalPrice.java
+++ b/src/main/java/org/galatea/starter/domain/IexHistoricalPrice.java
@@ -1,0 +1,20 @@
+package org.galatea.starter.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+@Data
+@Builder
+public class IexHistoricalPrice {
+
+  private String symbol;
+  private Date date;
+  private BigDecimal open;
+  private BigDecimal close;
+  private BigDecimal high;
+  private BigDecimal low;
+  private BigDecimal volume;
+}

--- a/src/main/java/org/galatea/starter/domain/IexSymbol.java
+++ b/src/main/java/org/galatea/starter/domain/IexSymbol.java
@@ -1,6 +1,6 @@
 package org.galatea.starter.domain;
 
-import java.util.Date;
+import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Data;
 
@@ -10,7 +10,7 @@ public class IexSymbol {
 
   private String symbol;
   private String name;
-  private Date date;
+  private LocalDate date;
   private boolean isEnabled;
   private String type;
   private String iexId;

--- a/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
+++ b/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
@@ -1,5 +1,9 @@
 package org.galatea.starter.entrypoint;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +14,8 @@ import org.galatea.starter.domain.IexHistoricalPrice;
 import org.galatea.starter.domain.IexLastTradedPrice;
 import org.galatea.starter.domain.IexSymbol;
 import org.galatea.starter.service.IexService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,8 +32,11 @@ public class IexRestController {
   @NonNull
   private IexService iexService;
 
+  @Value("${spring.rest.iexValidRanges}")
+  private List<String> iexValidRanges;
+
   /**
-   * Exposes an endpoint to get all of the symbols available on IEX.
+   * Exposes an endpoint to get all the symbols available on IEX.
    *
    * @return a list of all IexStockSymbols.
    */
@@ -43,24 +52,73 @@ public class IexRestController {
    * @return a List of IexLastTradedPrice objects for the given symbols.
    */
   @GetMapping(value = "${mvc.iex.getLastTradedPricePath}", produces = {
-      MediaType.APPLICATION_JSON_VALUE})
+          MediaType.APPLICATION_JSON_VALUE})
   public List<IexLastTradedPrice> getLastTradedPrice(
-      @RequestParam(value = "symbols") final List<String> symbols) {
+          @RequestParam(value = "symbols") final List<String> symbols) {
     return iexService.getLastTradedPriceForSymbols(symbols);
   }
 
   /**
    * Get historical pricing data for the given symbol on the given date
    *
-   * @param symbol the symbol to retrieve data about
-   * @param date the date which should be queried
+   * @param symbols the symbol to retrieve data about
+   * @param dates   the date which should be queried
    * @return historical pricing data for the given symbol on the given date
    */
   @GetMapping(value = "${mvc.iex.getHistoricalPricePath}", produces = {
           MediaType.APPLICATION_JSON_VALUE})
   public List<IexHistoricalPrice> getHistoricalPrice(
-          @RequestParam(value = "symbol") final List<String> symbol,
-          @RequestParam(value = "date") final List<String> date) {
-    return iexService.getHistoricalPrice(symbol, date);
+          @RequestParam(value = "symbol", required = true) final List<String> symbols,
+          @RequestParam(value = "range", required = false) final List<String> ranges,
+          @RequestParam(value = "date", required = false) @DateTimeFormat(pattern = "yyyyMMdd") final List<LocalDate> dates) {
+    //date mode
+    if ((symbols.size() == 1) && (dates != null) && (dates.size() == 1) && (ranges == null)) {
+      LocalDate date = dates.get(0);
+
+      if (checkValidDate(date)) {
+        return iexService.getHistoricalPriceOnDate(symbols.get(0), dates.get(0));
+      }
+      else {
+        return Collections.emptyList();
+      }
+    }
+    //range mode
+    else if ((symbols.size() == 1) && (dates == null) && (ranges != null) && (ranges.size() == 1)) {
+      String range = ranges.get(0);
+
+      if (checkValidRange(range)) {
+        return iexService.getHistoricalPriceForRange(symbols.get(0), ranges.get(0));
+      }
+      else {
+        return Collections.emptyList();
+      }
+    }
+    //invalid
+    else {
+      return Collections.emptyList();
+    }
+  }
+
+  /**
+   * Checks if a given date is valid
+   *
+   * @param date date to check
+   * @return validity
+   */
+  private boolean checkValidDate(LocalDate date) {
+    LocalDate today = LocalDate.now();
+
+    //check if data is in the past
+    return date.isBefore(today);
+  }
+
+  /**
+   * Checks if a given range is valid
+   *
+   * @param range range to check
+   * @return validity
+   */
+  private boolean checkValidRange(String range) {
+    return iexValidRanges.contains(range);
   }
 }

--- a/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
+++ b/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.sf.aspect4log.Log;
 import net.sf.aspect4log.Log.Level;
+import org.galatea.starter.domain.IexHistoricalPrice;
 import org.galatea.starter.domain.IexLastTradedPrice;
 import org.galatea.starter.domain.IexSymbol;
 import org.galatea.starter.service.IexService;
@@ -48,4 +49,18 @@ public class IexRestController {
     return iexService.getLastTradedPriceForSymbols(symbols);
   }
 
+  /**
+   * Get historical pricing data for the given symbol on the given date
+   *
+   * @param symbol the symbol to retrieve data about
+   * @param date the date which should be queried
+   * @return historical pricing data for the given symbol on the given date
+   */
+  @GetMapping(value = "${mvc.iex.getHistoricalPricePath}", produces = {
+          MediaType.APPLICATION_JSON_VALUE})
+  public List<IexHistoricalPrice> getHistoricalPrice(
+          @RequestParam(value = "symbol") final List<String> symbol,
+          @RequestParam(value = "date") final List<String> date) {
+    return iexService.getHistoricalPrice(symbol, date);
+  }
 }

--- a/src/main/java/org/galatea/starter/service/IexClient.java
+++ b/src/main/java/org/galatea/starter/service/IexClient.java
@@ -1,10 +1,13 @@
 package org.galatea.starter.service;
 
 import java.util.List;
+
+import org.galatea.starter.domain.IexHistoricalPrice;
 import org.galatea.starter.domain.IexLastTradedPrice;
 import org.galatea.starter.domain.IexSymbol;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -32,4 +35,13 @@ public interface IexClient {
   @GetMapping("/tops/last?token=${spring.rest.iexToken}")
   List<IexLastTradedPrice> getLastTradedPriceForSymbols(@RequestParam("symbols") String[] symbols);
 
+  /**
+   * Get historical pricing data for the given symbol on the given date. See https://iexcloud.io/docs/api/#historical-prices
+   *
+   * @param symbol the symbol to retrieve data about
+   * @param date the date which should be queried
+   * @return historical pricing data for the given symbol on the given date
+   */
+  @GetMapping("/stock/{symbol}/chart/date/{date}?chartByDay=true&token=${spring.rest.iexToken}")
+  List<IexHistoricalPrice> getHistoricalPrice(@PathVariable(value="symbol") String symbol, @PathVariable(value="date") String date);
 }

--- a/src/main/java/org/galatea/starter/service/IexClient.java
+++ b/src/main/java/org/galatea/starter/service/IexClient.java
@@ -1,11 +1,15 @@
 package org.galatea.starter.service;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+import feign.Param;
 import org.galatea.starter.domain.IexHistoricalPrice;
 import org.galatea.starter.domain.IexLastTradedPrice;
 import org.galatea.starter.domain.IexSymbol;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -39,9 +43,30 @@ public interface IexClient {
    * Get historical pricing data for the given symbol on the given date. See https://iexcloud.io/docs/api/#historical-prices
    *
    * @param symbol the symbol to retrieve data about
-   * @param date the date which should be queried
+   * @param date the date which should be queried (in "yyyyMMdd" String format)
    * @return historical pricing data for the given symbol on the given date
    */
   @GetMapping("/stock/{symbol}/chart/date/{date}?chartByDay=true&token=${spring.rest.iexToken}")
-  List<IexHistoricalPrice> getHistoricalPrice(@PathVariable(value="symbol") String symbol, @PathVariable(value="date") String date);
+  List<IexHistoricalPrice> getHistoricalPriceOnDate(@PathVariable(value="symbol") String symbol, @PathVariable(value="date") String date);
+
+  /**
+   * Helper method to convert LocalDate format dates in the string format required by IEX
+   *
+   * @param symbol the symbol to retrieve data about
+   * @param date the date which should be queried (in LocalDate format)
+   * @return historical pricing data for the given symbol on the given date
+   */
+  default List<IexHistoricalPrice> getHistoricalPriceOnDate(String symbol, LocalDate date) {
+    return getHistoricalPriceOnDate(symbol, date.format(DateTimeFormatter.ofPattern("yyyyMMdd")));
+  }
+
+  /**
+   * Get historical pricing data for the given symbol and range. See https://iexcloud.io/docs/api/#historical-prices
+   *
+   * @param symbol the symbol to retrieve data about
+   * @param range the range to query (max, 5y, 2y, 1y, ytd, 6m, 3m, 1m, 1mm, 5d, 5dm, date, dynamic)
+   * @return historical pricing data for the given symbol on the given date
+   */
+  @GetMapping("/stock/{symbol}/chart/{range}?token=${spring.rest.iexToken}")
+  List<IexHistoricalPrice> getHistoricalPriceForRange(@PathVariable(value="symbol") String symbol, @PathVariable(value="range") String range);
 }

--- a/src/main/java/org/galatea/starter/service/IexService.java
+++ b/src/main/java/org/galatea/starter/service/IexService.java
@@ -1,10 +1,12 @@
 package org.galatea.starter.service;
 
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.galatea.starter.domain.IexHistoricalPrice;
 import org.galatea.starter.domain.IexLastTradedPrice;
 import org.galatea.starter.domain.IexSymbol;
 import org.springframework.stereotype.Service;
@@ -45,5 +47,20 @@ public class IexService {
     }
   }
 
+  /**
+   * Get historical pricing data for the given symbol on the given date
+   *
+   * @param symbol the symbol to retrieve data about
+   * @param date the date which should be queried
+   * @return historical pricing data for the given symbol on the given date
+   */
+  public List<IexHistoricalPrice> getHistoricalPrice(final List<String> symbol, final List<String> date) {
+    if ((symbol.size() == 1) && (date.size() == 1)) {
+      return iexClient.getHistoricalPrice(symbol.get(0), date.get(0));
+    }
+    else {
+      return Collections.emptyList();
+    }
+  }
 
 }

--- a/src/main/java/org/galatea/starter/service/IexService.java
+++ b/src/main/java/org/galatea/starter/service/IexService.java
@@ -1,6 +1,7 @@
 package org.galatea.starter.service;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import lombok.NonNull;
@@ -54,13 +55,19 @@ public class IexService {
    * @param date the date which should be queried
    * @return historical pricing data for the given symbol on the given date
    */
-  public List<IexHistoricalPrice> getHistoricalPrice(final List<String> symbol, final List<String> date) {
-    if ((symbol.size() == 1) && (date.size() == 1)) {
-      return iexClient.getHistoricalPrice(symbol.get(0), date.get(0));
-    }
-    else {
-      return Collections.emptyList();
-    }
+  public List<IexHistoricalPrice> getHistoricalPriceOnDate(final String symbol, final LocalDate date) {
+    return iexClient.getHistoricalPriceOnDate(symbol, date);
+  }
+
+  /**
+   * Get historical pricing data for the given symbol and range
+   *
+   * @param symbol the symbol to retrieve data about
+   * @param range the range to query (max, 5y, 2y, 1y, ytd, 6m, 3m, 1m, 1mm, 5d, 5dm, date, dynamic)
+   * @return historical pricing data for the given symbol on the given date
+   */
+  public List<IexHistoricalPrice> getHistoricalPriceForRange(final String symbol, final String range) {
+    return iexClient.getHistoricalPriceForRange(symbol, range);
   }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,7 @@ mvc:
    iex:
       getAllSymbolsPath: /iex/symbols
       getLastTradedPricePath: /iex/lastTradedPrice
+      getHistoricalPricePath: /iex/historicalPrice
    max-size-trace-payload: 50000
 jms:
    listener-concurrency: 1-5

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,6 +49,7 @@ spring:
       # this points at the local WireMock server in the test environment.
       iexBasePath: http://localhost:${wiremock.server.port}/
       iexToken: DUMMY_TOKEN
+      iexValidRanges: max,5y,2y,1y,ytd,6m,3m,1m,1mm,5d,5dm,date,dynamic
 
 ---
 # Dev properties go here
@@ -60,6 +61,7 @@ spring:
    rest:
       iexBasePath: https://cloud.iexapis.com/stable
       iexToken: YOUR_TOKEN_HERE
+      iexValidRanges: max,5y,2y,1y,ytd,6m,3m,1m,1mm,5d,5dm,date,dynamic
 # set debug to get spring to log the classpath (and other things) on startup
 debug: true
 

--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -81,4 +81,44 @@ public class IexRestControllerTest extends ASpringTest {
         .andExpect(jsonPath("$", is(Collections.emptyList())))
         .andReturn();
   }
+
+  @Test
+  public void testGetHistoricalPrice() throws Exception {
+
+    MvcResult result = this.mvc.perform(
+                    org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                            .get("/iex/historicalPrice?symbol=AAPL&date=20181214")
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].symbol", is("AAPL")))
+            .andExpect(jsonPath("$[0].open").value(new BigDecimal("42.25")))
+            .andExpect(jsonPath("$[0].close").value(new BigDecimal("41.37")))
+            .andReturn();
+  }
+
+  @Test
+  public void testGetHistoricalPriceEmptySymbol() throws Exception {
+
+    MvcResult result1 = this.mvc.perform(
+                    org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                            .get("/iex/historicalPrice?symbol=&date=20181214")
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", is(Collections.emptyList())))
+            .andReturn();
+  }
+
+  @Test
+  public void testGetHistoricalPriceEmptyDate() throws Exception {
+
+    MvcResult result1 = this.mvc.perform(
+                    org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                            .get("/iex/historicalPrice?symbol=AAPL&date=")
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", is(Collections.emptyList())))
+            .andReturn();
+  }
 }

--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -83,7 +83,7 @@ public class IexRestControllerTest extends ASpringTest {
   }
 
   @Test
-  public void testGetHistoricalPrice() throws Exception {
+  public void testGetHistoricalPriceDate() throws Exception {
 
     MvcResult result = this.mvc.perform(
                     org.springframework.test.web.servlet.request.MockMvcRequestBuilders
@@ -97,26 +97,79 @@ public class IexRestControllerTest extends ASpringTest {
   }
 
   @Test
-  public void testGetHistoricalPriceEmptySymbol() throws Exception {
-
+  public void testGetHistoricalPriceDateEmptySymbol() throws Exception {
     MvcResult result1 = this.mvc.perform(
                     org.springframework.test.web.servlet.request.MockMvcRequestBuilders
                             .get("/iex/historicalPrice?symbol=&date=20181214")
                             .accept(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(status().isOk())
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", is(Collections.emptyList())))
             .andReturn();
   }
 
   @Test
-  public void testGetHistoricalPriceEmptyDate() throws Exception {
-
+  public void testGetHistoricalPriceDateEmptyDate() throws Exception {
     MvcResult result1 = this.mvc.perform(
                     org.springframework.test.web.servlet.request.MockMvcRequestBuilders
                             .get("/iex/historicalPrice?symbol=AAPL&date=")
                             .accept(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isOk())
+            .andExpect(jsonPath("$", is(Collections.emptyList())))
+            .andReturn();
+  }
+
+  @Test
+  public void testGetHistoricalPriceDateInvalidDate() throws Exception {
+    MvcResult result1 = this.mvc.perform(
+                    org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                            .get("/iex/historicalPrice?symbol=AAPL&date=20981011")
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", is(Collections.emptyList())))
+            .andReturn();
+  }
+
+  @Test
+  public void testGetHistoricalPriceRange() throws Exception {
+    MvcResult result = this.mvc.perform(
+                    org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                            .get("/iex/historicalPrice?symbol=AAPL&range=ytd")
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].symbol", is("AAPL")))
+            .andExpect(jsonPath("$[0].open").value(new BigDecimal("42.25")))
+            .andExpect(jsonPath("$[0].close").value(new BigDecimal("41.37")))
+            .andReturn();
+  }
+
+  @Test
+  public void testGetHistoricalPriceRangeEmptySymbol() throws Exception {
+    MvcResult result = this.mvc.perform(
+                    org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                            .get("/iex/historicalPrice?symbol=&range=ytd")
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", is(Collections.emptyList())))
+            .andReturn();
+  }
+
+  @Test
+  public void testGetHistoricalPriceRangeEmptyRange() throws Exception {
+    MvcResult result = this.mvc.perform(
+                    org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                            .get("/iex/historicalPrice?symbol=AAPL&range=")
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", is(Collections.emptyList())))
+            .andReturn();
+  }
+
+  @Test
+  public void testGetHistoricalPriceRangeInvalidRange() throws Exception {
+    MvcResult result = this.mvc.perform(
+                    org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                            .get("/iex/historicalPrice?symbol=AAPL&range=zzzzzz")
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", is(Collections.emptyList())))
             .andReturn();

--- a/src/test/resources/wiremock/mappings/mapping-historicalPrice.json
+++ b/src/test/resources/wiremock/mappings/mapping-historicalPrice.json
@@ -1,0 +1,40 @@
+{
+  "id" : "16369e06-78d4-40a7-98d1-3dbe0ba82fd6",
+  "name" : "historical_price",
+  "request" : {
+    "url" : "/stock/AAPL/chart/date/20181214?chartByDay=true&token=DUMMY_TOKEN",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "jsonBody" : [{
+      "symbol": "AAPL",
+      "date": 1544745600000,
+      "open": 42.25,
+      "close": 41.37,
+      "high": 42.27,
+      "low": 41.32,
+      "volume": 162814840
+    }],
+    "headers" : {
+      "Server" : "nginx",
+      "Date" : "Thu, 08 Aug 2019 14:08:53 GMT",
+      "Content-Type" : "application/json; charset=utf-8",
+      "Connection" : "keep-alive",
+      "set-cookie" : "ctoken=958c0e17a3f542a2a13ef676b670326d; Domain=.iextrading.com; Path=/; Expires=Fri, 09 Aug 2019 02:08:53 GMT; Secure",
+      "Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+      "X-Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+      "Frame-Options" : "SAMEORIGIN",
+      "X-Frame-Options" : "SAMEORIGIN",
+      "X-Content-Type-Options" : "nosniff",
+      "Strict-Transport-Security" : "max-age=15768000",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Credentials" : "true",
+      "Access-Control-Allow-Methods" : "GET, OPTIONS",
+      "Access-Control-Allow-Headers" : "Origin, X-Requested-With, Content-Type, Accept"
+    }
+  },
+  "uuid" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+  "persistent" : true,
+  "insertionIndex" : 5
+}

--- a/src/test/resources/wiremock/mappings/mapping-historicalPriceDate.json
+++ b/src/test/resources/wiremock/mappings/mapping-historicalPriceDate.json
@@ -1,6 +1,6 @@
 {
   "id" : "16369e06-78d4-40a7-98d1-3dbe0ba82fd6",
-  "name" : "historical_price",
+  "name" : "historical_price_date",
   "request" : {
     "url" : "/stock/AAPL/chart/date/20181214?chartByDay=true&token=DUMMY_TOKEN",
     "method" : "GET"

--- a/src/test/resources/wiremock/mappings/mapping-historicalPriceRange.json
+++ b/src/test/resources/wiremock/mappings/mapping-historicalPriceRange.json
@@ -1,0 +1,40 @@
+{
+  "id" : "16369e06-78d4-40a7-98d1-3dbe0ba82fd6",
+  "name" : "historical_price_range",
+  "request" : {
+    "url" : "/stock/AAPL/chart/ytd?token=DUMMY_TOKEN",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "jsonBody" : [{
+      "symbol": "AAPL",
+      "date": 1544745600000,
+      "open": 42.25,
+      "close": 41.37,
+      "high": 42.27,
+      "low": 41.32,
+      "volume": 162814840
+    }],
+    "headers" : {
+      "Server" : "nginx",
+      "Date" : "Thu, 08 Aug 2019 14:08:53 GMT",
+      "Content-Type" : "application/json; charset=utf-8",
+      "Connection" : "keep-alive",
+      "set-cookie" : "ctoken=958c0e17a3f542a2a13ef676b670326d; Domain=.iextrading.com; Path=/; Expires=Fri, 09 Aug 2019 02:08:53 GMT; Secure",
+      "Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+      "X-Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+      "Frame-Options" : "SAMEORIGIN",
+      "X-Frame-Options" : "SAMEORIGIN",
+      "X-Content-Type-Options" : "nosniff",
+      "Strict-Transport-Security" : "max-age=15768000",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Credentials" : "true",
+      "Access-Control-Allow-Methods" : "GET, OPTIONS",
+      "Access-Control-Allow-Headers" : "Origin, X-Requested-With, Content-Type, Accept"
+    }
+  },
+  "uuid" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+  "persistent" : true,
+  "insertionIndex" : 5
+}


### PR DESCRIPTION
# Design
New FUSE API endpoint: */iex/historicalPrice*
With two request parameters:
>*Symbol*: symbol to retrieve data about
>*Date*: Date to query (in format YYYYMMDD)
    
Example: 
>*/iex/historicalPrice?symbol=AAPL&date=20181214*

Retrieves data about AAPL (apple) from 2018-12-14

This consumes the IEX endpoint:
>*/stock/**{symbol}**/chart/date/**{date}**?chartByDay=true&token=DUMMY_TOKEN*

See: https://iexcloud.io/docs/api/#historical-prices 

# Test
New test defined to test the historicalPrice endpoint with valid parameters: 
![test code](https://user-images.githubusercontent.com/115724737/196479199-55facf99-2432-4140-ab5a-d09c9903b97c.PNG)

New tests defined to test the historicalPrice endpoint with invalid parameters: 
![invalid tests](https://user-images.githubusercontent.com/115724737/196479283-3bb4b0bc-8a6f-4592-8d49-0b02727044df.PNG)

Wiremock simulation of IEX historical-prices added:
![wiremock](https://user-images.githubusercontent.com/115724737/196479344-cd4a4ab6-4eb4-49be-bc25-22dbf6b28049.PNG)

All tests passing:
![tests](https://user-images.githubusercontent.com/115724737/196479386-35872cf6-e511-4b62-9b63-8dd7dbfe8bac.PNG)

